### PR TITLE
[INVALID] Fixing decimal capture bug and misleading calculations on order details page.

### DIFF
--- a/adm-core.php
+++ b/adm-core.php
@@ -110,4 +110,14 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 			}
 		}
 	}
+
+	/**
+	 * @param string $number
+	 * @return float
+	 */
+	function format_amount($number) {
+		$number_string = str_replace(',', '', str_replace('.', '', $number));
+		$number = floatval(substr($number_string, 0, strlen($number_string) - 2) . "." . substr($number_string, strlen($number_string) - 2 , strlen($number_string)));
+		return $number;
+	}
 }

--- a/adm-core.php
+++ b/adm-core.php
@@ -116,8 +116,13 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 	 * @return float
 	 */
 	function format_amount($number) {
+		if(strrpos($number, '.') || strrpos($number, ',')) {
+			$decimals = strlen($number) - max( strrpos($number, ',') , strrpos($number, '.') ) - 1;
+		} else {
+			$decimals = 0;
+		}
 		$number_string = str_replace(',', '', str_replace('.', '', $number));
-		$number = floatval(substr($number_string, 0, strlen($number_string) - 2) . "." . substr($number_string, strlen($number_string) - 2 , strlen($number_string)));
+		$number = floatval( substr($number_string, 0, strlen($number_string) - $decimals) . "." . substr($number_string, strlen($number_string) - $decimals , strlen($number_string)) );
 		return $number;
 	}
 }

--- a/assets/admin/js/anyday-admin.js
+++ b/assets/admin/js/anyday-admin.js
@@ -13,7 +13,6 @@
         var amount = prompt(anyday.capturePrompt);
 
         if(amount === null) return;
-
         amount = validateAmount(amount);
 
         if(!amount) {
@@ -29,8 +28,7 @@
       } else if (action === 'adm_refund_payment') {
         var amount = prompt(anyday.refundConfirmation);
 
-        if(amount === null) return;
-
+        if (amount === null) return;
         amount = validateAmount(amount);
 
         if(!amount) {
@@ -57,11 +55,17 @@
     });
 
     function validateAmount(amount) {
-      let amtPattern = /^((?:\d{1,3}(?:[\s,]\d{3})+|\d+)(?:.\d{0,2}$))$|^((?:\d{1,3}(?:[\s.]\d{3})+|\d+)(?:,\d{0,2}$)|(^\d+$))$/;
+      let amtPattern = /^((?:\d{1,3}((?:[\s,]\d{3})+|(?:,\d{0,2}))(?:\.\d{0,2})?)$|^(?:\d{1,3}((?:[\s.]\d{3})+|(?:\.\d{0,2}))(?:\,\d{0,2})?)$|(^\d+[,\.]?)$|(?:\d+[,\.]\d{0,2})$)/;
       var dotPattern = [];
       var zeroReg    = /^0+$/;
       var amt        = false;
       var dec, decLength;
+      if ((amount.charAt(0) == '.' || amount.charAt(0) == ',')) {
+        dotPattern = amount.match(/[,|\.]/g);
+        if (dotPattern.length == 1) {
+          amount = "0" + amount;
+        }
+      }
       if(amtPattern.test(amount)) {
         dotPattern = amount.match(/[,|\.]/g);
         amt = amount.match(/\d+/g).join('');
@@ -70,7 +74,9 @@
         if(dotPattern && dotPattern.length > 0) {
           dec = dotPattern[dotPattern.length - 1];
           decLength = amount.split(dec)[1].length;
-          amt = amt.substring(0, amt.length - decLength) + "." + amt.substring(amt.length - decLength);
+          if ((amount.split(dec)[0] == "0" && dotPattern.length != 1) || decLength <= 2 ) {
+            amt = amt.substring(0, amt.length - decLength) + "." + amt.substring(amt.length - decLength);
+          }
         } else {
           return amt;
         }

--- a/includes/classes/AnydayPayment.php
+++ b/includes/classes/AnydayPayment.php
@@ -138,14 +138,14 @@ class AnydayPayment
 		$id = ($order_id) ? $order_id : $_POST['orderId'];
 		$order = wc_get_order( $id );
 		$amount = ($amount) ? $amount : $_POST['amount'];
-		$amount = number_format($amount, 2, ',', '');
+		$amount = format_amount($amount);
 		$response = $this->adm_api_capture( $order, $amount );
 
 		if ( $response ) {
 
 			if ( !$this->handled( $order, $response->transactionId ) ) {
 
-				update_post_meta( $order->get_id(), date("Y-m-d_h:i:sa") . '_anyday_captured_payment', wc_clean( $amount ) );
+				update_post_meta( $order->get_id(), date("Y-m-d_h:i:sa") . '_anyday_captured_payment', wc_clean( number_format($amount, 2, ',', '') ) );
 				if( get_option('adm_order_status_after_captured_payment') != "default" ) {
 
 					$order->update_status( get_option('adm_order_status_after_captured_payment'), __( 'Anyday payment captured!', 'adm' ) );
@@ -289,13 +289,13 @@ class AnydayPayment
 		$id = ($order_id) ? $order_id : $_POST['orderId'];
 		$order = wc_get_order( $id );
 		$amount = ($amount) ? $amount : $_POST['amount'];
-		$amount = number_format($amount, 2, ',', '');
+		$amount = format_amount($amount);
 		$response = $this->adm_api_refund( $order, $amount );
 
 		if( $response ) {
 			if (!$this->handled($order, $response->transactionId)) {
 
-				update_post_meta($order->get_id(), date("Y-m-d_h:i:sa") . '_anyday_refunded_payment', wc_clean($amount));
+				update_post_meta($order->get_id(), date("Y-m-d_h:i:sa") . '_anyday_refunded_payment', wc_clean( number_format($amount, 2, ',', '') ));
 
 				$order->update_status('wc-adm-refunded', __('Anyday payment refunded!', 'adm'));
 

--- a/includes/classes/AnydayPayment.php
+++ b/includes/classes/AnydayPayment.php
@@ -138,14 +138,13 @@ class AnydayPayment
 		$id = ($order_id) ? $order_id : $_POST['orderId'];
 		$order = wc_get_order( $id );
 		$amount = ($amount) ? $amount : $_POST['amount'];
-		$amount = format_amount($amount);
 		$response = $this->adm_api_capture( $order, $amount );
 
 		if ( $response ) {
 
 			if ( !$this->handled( $order, $response->transactionId ) ) {
 
-				update_post_meta( $order->get_id(), date("Y-m-d_h:i:sa") . '_anyday_captured_payment', wc_clean( number_format($amount, 2, ',', '') ) );
+				update_post_meta( $order->get_id(), date("Y-m-d_h:i:sa") . '_anyday_captured_payment', wc_clean( $amount ) );
 				if( get_option('adm_order_status_after_captured_payment') != "default" ) {
 
 					$order->update_status( get_option('adm_order_status_after_captured_payment'), __( 'Anyday payment captured!', 'adm' ) );
@@ -289,13 +288,12 @@ class AnydayPayment
 		$id = ($order_id) ? $order_id : $_POST['orderId'];
 		$order = wc_get_order( $id );
 		$amount = ($amount) ? $amount : $_POST['amount'];
-		$amount = format_amount($amount);
 		$response = $this->adm_api_refund( $order, $amount );
 
 		if( $response ) {
 			if (!$this->handled($order, $response->transactionId)) {
 
-				update_post_meta($order->get_id(), date("Y-m-d_h:i:sa") . '_anyday_refunded_payment', wc_clean( number_format($amount, 2, ',', '') ));
+				update_post_meta($order->get_id(), date("Y-m-d_h:i:sa") . '_anyday_refunded_payment', wc_clean( $amount) );
 
 				$order->update_status('wc-adm-refunded', __('Anyday payment refunded!', 'adm'));
 

--- a/includes/classes/AnydayWooOrder.php
+++ b/includes/classes/AnydayWooOrder.php
@@ -86,18 +86,18 @@ class AnydayWooOrder
 
 		foreach( get_post_meta( $order->get_id() ) as $key => $meta ) {
 			if( strpos($key, 'anyday_captured_payment') !== false ) {
-				$captured_amount += $this->format_amount($meta[0]);
+				$captured_amount += format_amount($meta[0]);
 			}
 
 			if( strpos($key, 'anyday_refunded_payment') !== false ) {
-				$refunded_amount += $this->format_amount($meta[0]);
+				$refunded_amount += format_amount($meta[0]);
 			}
 
 			if ( ($order->get_total() - $captured_amount ) == 0 ) {
 				update_post_meta( $order->get_id(),'full_captured_amount', 'true' );
 			}
 
-			if ( ($captured_amount - $refunded_amount) == 0 ) {
+			if ( $captured_amount && ($captured_amount - $refunded_amount) == 0 ) {
 				update_post_meta( $order->get_id(),'full_refunded_amount', 'true' );
 			}
 		}
@@ -125,7 +125,7 @@ width: 100%;margin-top: 20px;">
 				<table class="woocommerce_order_items" cellspacing="0" cellpadding="0">
 					<tbody id="order_refunds">
 						<?php foreach( get_post_meta( $order->get_id() ) as $key => $meta ) :?>
-							<?php if( strpos($key, 'anyday_captured_payment') !== false ) : $captured_amount = $captured_amount + $this->format_amount($meta[0]);?>
+							<?php if( strpos($key, 'anyday_captured_payment') !== false ) : $captured_amount = $captured_amount + format_amount($meta[0]);?>
 								<tr class="refund ">
 									<td class="thumb">
 										<div></div>
@@ -136,7 +136,7 @@ width: 100%;margin-top: 20px;">
 									</td>
 									<td class="line_cost" width="1%">
 										<div class="view">
-											<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format($this->format_amount($meta[0]), 2, ',', '.'); ?></span>
+											<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format(format_amount($meta[0]), 2, ',', '.'); ?></span>
 										</div>
 									</td>
 								</tr>
@@ -180,7 +180,7 @@ width: 100%;margin-top: 20px;">
 				<table class="woocommerce_order_items" cellspacing="0" cellpadding="0">
 					<tbody id="order_refunds">
 						<?php foreach( get_post_meta( $order->get_id() ) as $key => $meta ) :?>
-							<?php if( strpos($key, 'anyday_refunded_payment') !== false ) : $refunded_amount = $refunded_amount + $this->format_amount($meta[0]);?>
+							<?php if( strpos($key, 'anyday_refunded_payment') !== false ) : $refunded_amount = $refunded_amount + format_amount($meta[0]);?>
 								<tr class="refund ">
 									<td class="thumb">
 										<div></div>
@@ -191,7 +191,7 @@ width: 100%;margin-top: 20px;">
 									</td>
 									<td class="line_cost" width="1%">
 										<div class="view">
-											<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format($this->format_amount($meta[0]), 2, ',', '.'); ?></span>
+											<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format(format_amount($meta[0]), 2, ',', '.'); ?></span>
 										</div>
 									</td>
 								</tr>
@@ -478,7 +478,7 @@ width: 100%;margin-top: 20px;">
 		$captured_amount = 0;
 		foreach( get_post_meta( $order->get_id() ) as $key => $meta ) {
 			if( strpos($key, 'anyday_captured_payment') !== false ) {
-				$captured_amount += $this->format_amount($meta[0]);
+				$captured_amount += format_amount($meta[0]);
 			}
 		}
 		return $captured_amount;
@@ -492,19 +492,9 @@ width: 100%;margin-top: 20px;">
 		$refunded_amount = 0;
 		foreach (get_post_meta($order->get_id()) as $key => $meta) {
 			if (strpos($key, 'anyday_refunded_payment') !== false) {
-					$refunded_amount += $this->format_amount($meta[0]);
+					$refunded_amount += format_amount($meta[0]);
 			}
 		}
 		return $refunded_amount;
-	}
-
-	/**
-	 * @param string $number
-	 * @return 
-	 */
-	private function format_amount($number) {
-		$number_string = str_replace(',', '', str_replace('.', '', $number));
-		$number = floatval(substr($number_string, 0, strlen($number_string) - 2) . "." . substr($number_string, strlen($number_string) - 2 , strlen($number_string)));
-		return $number;
 	}
 }

--- a/includes/classes/AnydayWooOrder.php
+++ b/includes/classes/AnydayWooOrder.php
@@ -86,22 +86,21 @@ class AnydayWooOrder
 
 		foreach( get_post_meta( $order->get_id() ) as $key => $meta ) {
 			if( strpos($key, 'anyday_captured_payment') !== false ) {
-				$captured_amount += $meta[0];
+				$captured_amount += $this->format_amount($meta[0]);
 			}
 
 			if( strpos($key, 'anyday_refunded_payment') !== false ) {
-				$refunded_amount += $meta[0];
+				$refunded_amount += $this->format_amount($meta[0]);
 			}
 
-			if ( ((float)$order->get_total() - (float)$captured_amount) == 0 ) {
+			if ( ($order->get_total() - $captured_amount ) == 0 ) {
 				update_post_meta( $order->get_id(),'full_captured_amount', 'true' );
 			}
 
-			if ( ((float)$order->get_total() - (float)$refunded_amount) == 0 ) {
+			if ( ($captured_amount - $refunded_amount) == 0 ) {
 				update_post_meta( $order->get_id(),'full_refunded_amount', 'true' );
 			}
 		}
-
 
 		if( $order->get_payment_method() == 'anyday_payment_gateway' ) {
 			if ( $order->get_status() != 'cancelled' ) {
@@ -119,7 +118,6 @@ class AnydayWooOrder
 			}
 
 			$captured_amount = 0;
-			$refunded_amount = 0;
 			?>
 			<div class="woocommerce_order_items_wrapper wc-order-items-editable" style="display: block;
 width: 100%;margin-top: 20px;">
@@ -127,7 +125,7 @@ width: 100%;margin-top: 20px;">
 				<table class="woocommerce_order_items" cellspacing="0" cellpadding="0">
 					<tbody id="order_refunds">
 						<?php foreach( get_post_meta( $order->get_id() ) as $key => $meta ) :?>
-							<?php if( strpos($key, 'anyday_captured_payment') !== false ) : $captured_amount = $captured_amount + $meta[0];?>
+							<?php if( strpos($key, 'anyday_captured_payment') !== false ) : $captured_amount = $captured_amount + $this->format_amount($meta[0]);?>
 								<tr class="refund ">
 									<td class="thumb">
 										<div></div>
@@ -138,7 +136,7 @@ width: 100%;margin-top: 20px;">
 									</td>
 									<td class="line_cost" width="1%">
 										<div class="view">
-											<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format((float)$meta[0], 2, ',', '.'); ?></span>
+											<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format($this->format_amount($meta[0]), 2, ',', '.'); ?></span>
 										</div>
 									</td>
 								</tr>
@@ -154,16 +152,16 @@ width: 100%;margin-top: 20px;">
 									<td class="label refunded-total">Total Captured Amount:</td>
 									<td width="1%"></td>
 									<td class="total refunded-total">
-										<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format((float)$captured_amount, 2, ',', '.'); ?></span>
+										<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format($captured_amount, 2, ',', '.'); ?></span>
 									</td>
 								</tr>
 								<tr>
 									<td class="label">Amount left to be Captured:</td>
 									<td width="1%"></td>
 									<td class="total">
-										<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format((float)$order->get_total() - (float)$captured_amount, 2, ',', '.');
+										<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format((float)$order->get_total() - (float)$captured_amount + $refunded_amount, 2, ',', '.');
 
-										if ( ((float)$order->get_total() - (float)$captured_amount) == 0 ) {
+										if ( ((float)$order->get_total() - $captured_amount) == 0 ) {
 											update_post_meta( $order->get_id(),'full_captured_amount', 'true' );
 										}
 										?></span>
@@ -175,13 +173,14 @@ width: 100%;margin-top: 20px;">
 					</div>
 				<?php endif; ?>
 			</div>
+			<?php $refunded_amount = 0;?>
 			<div class="woocommerce_order_items_wrapper wc-order-items-editable" style="display: block;
 width: 100%;margin-top: 20px;">
 				<span id="anyday-order-message"></span>
 				<table class="woocommerce_order_items" cellspacing="0" cellpadding="0">
 					<tbody id="order_refunds">
 						<?php foreach( get_post_meta( $order->get_id() ) as $key => $meta ) :?>
-							<?php if( strpos($key, 'anyday_refunded_payment') !== false ) : $refunded_amount = $refunded_amount + $meta[0];?>
+							<?php if( strpos($key, 'anyday_refunded_payment') !== false ) : $refunded_amount = $refunded_amount + $this->format_amount($meta[0]);?>
 								<tr class="refund ">
 									<td class="thumb">
 										<div></div>
@@ -192,7 +191,7 @@ width: 100%;margin-top: 20px;">
 									</td>
 									<td class="line_cost" width="1%">
 										<div class="view">
-											<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format((float)$meta[0], 2, ',', '.'); ?></span>
+											<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format($this->format_amount($meta[0]), 2, ',', '.'); ?></span>
 										</div>
 									</td>
 								</tr>
@@ -208,16 +207,16 @@ width: 100%;margin-top: 20px;">
 									<td class="label refunded-total">Total Refunded Amount:</td>
 									<td width="1%"></td>
 									<td class="total refunded-total">
-										<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format((float)$refunded_amount, 2, ',', '.'); ?></span>
+										<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format($refunded_amount, 2, ',', '.'); ?></span>
 									</td>
 								</tr>
 								<tr>
 									<td class="label">Amount left to be Refunded:</td>
 									<td width="1%"></td>
 									<td class="total">
-										<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo  number_format((float)$order->get_total() - (float)$refunded_amount, 2, ',', '.');
+										<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo  number_format($captured_amount - $refunded_amount, 2, ',', '.');
 
-										if ( ((float)$order->get_total() - (float)$refunded_amount) == 0 ) {
+										if ( ($order->get_total() - $refunded_amount) == 0 ) {
 											update_post_meta( $order->get_id(),'full_refunded_amount', 'true' );
 										}
 										?></span>
@@ -227,7 +226,7 @@ width: 100%;margin-top: 20px;">
 									<td class="label label-highlight">Net Payment:</td>
 									<td width="1%"></td>
 									<td class="total">
-									<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format((float)$captured_amount - $refunded_amount, 2, ',', '.'); ?></bdi></span></td>
+									<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format($captured_amount - $refunded_amount, 2, ',', '.'); ?></bdi></span></td>
 								</tr>
 							</tbody>
 						</table>
@@ -479,7 +478,7 @@ width: 100%;margin-top: 20px;">
 		$captured_amount = 0;
 		foreach( get_post_meta( $order->get_id() ) as $key => $meta ) {
 			if( strpos($key, 'anyday_captured_payment') !== false ) {
-				$captured_amount += $meta[0];
+				$captured_amount += $this->format_amount($meta[0]);
 			}
 		}
 		return $captured_amount;
@@ -493,9 +492,19 @@ width: 100%;margin-top: 20px;">
 		$refunded_amount = 0;
 		foreach (get_post_meta($order->get_id()) as $key => $meta) {
 			if (strpos($key, 'anyday_refunded_payment') !== false) {
-					$refunded_amount += $meta[0];
+					$refunded_amount += $this->format_amount($meta[0]);
 			}
 		}
 		return $refunded_amount;
+	}
+
+	/**
+	 * @param string $number
+	 * @return 
+	 */
+	private function format_amount($number) {
+		$number_string = str_replace(',', '', str_replace('.', '', $number));
+		$number = floatval(substr($number_string, 0, strlen($number_string) - 2) . "." . substr($number_string, strlen($number_string) - 2 , strlen($number_string)));
+		return $number;
 	}
 }

--- a/includes/classes/AnydayWooOrder.php
+++ b/includes/classes/AnydayWooOrder.php
@@ -99,12 +99,13 @@ class AnydayWooOrder
 
 			if ( $captured_amount && ($captured_amount - $refunded_amount) == 0 ) {
 				update_post_meta( $order->get_id(),'full_refunded_amount', 'true' );
+				$order->update_status('wc-adm-refunded');
 			}
 		}
 
 		if( $order->get_payment_method() == 'anyday_payment_gateway' ) {
 			if ( $order->get_status() != 'cancelled' ) {
-				if ( get_post_meta( $order->get_id(), 'full_captured_amount' )[0] != 'true' ) {
+				if ( !$refunded_amount && get_post_meta( $order->get_id(), 'full_captured_amount' )[0] != 'true' ) {
 					echo '<button type="button" class="button anyday-capture anyday-payment-action" data-anyday-action="adm_capture_payment" data-order-id="'.$order->get_id().'">'. __("Anyday Capture", "adm") .'</button>';
 				}
 

--- a/includes/classes/AnydayWooOrder.php
+++ b/includes/classes/AnydayWooOrder.php
@@ -86,11 +86,11 @@ class AnydayWooOrder
 
 		foreach( get_post_meta( $order->get_id() ) as $key => $meta ) {
 			if( strpos($key, 'anyday_captured_payment') !== false ) {
-				$captured_amount += format_amount($meta[0]);
+				$captured_amount += floatval($meta[0]);
 			}
 
 			if( strpos($key, 'anyday_refunded_payment') !== false ) {
-				$refunded_amount += format_amount($meta[0]);
+				$refunded_amount += floatval($meta[0]);
 			}
 
 			if ( ($order->get_total() - $captured_amount ) == 0 ) {
@@ -109,7 +109,7 @@ class AnydayWooOrder
 					echo '<button type="button" class="button anyday-capture anyday-payment-action" data-anyday-action="adm_capture_payment" data-order-id="'.$order->get_id().'">'. __("Anyday Capture", "adm") .'</button>';
 				}
 
-				if ( get_post_meta( $order->get_id(), 'full_captured_amount' )[0] != 'true' && get_post_meta( $order->get_id(), 'full_refunded_amount' )[0] != 'true' ) {
+				if ( !$refunded_amount && get_post_meta( $order->get_id(), 'full_captured_amount' )[0] != 'true' && get_post_meta( $order->get_id(), 'full_refunded_amount' )[0] != 'true' ) {
 					echo '<button type="button" class="button anyday-cancel anyday-payment-action" data-anyday-action="adm_cancel_payment" data-order-id="'.$order->get_id().'">'. __("Anyday Cancel", "adm") .'</button>';
 				}
 
@@ -126,7 +126,7 @@ width: 100%;margin-top: 20px;">
 				<table class="woocommerce_order_items" cellspacing="0" cellpadding="0">
 					<tbody id="order_refunds">
 						<?php foreach( get_post_meta( $order->get_id() ) as $key => $meta ) :?>
-							<?php if( strpos($key, 'anyday_captured_payment') !== false ) : $captured_amount = $captured_amount + format_amount($meta[0]);?>
+							<?php if( strpos($key, 'anyday_captured_payment') !== false ) : $captured_amount = $captured_amount + floatval($meta[0]);?>
 								<tr class="refund ">
 									<td class="thumb">
 										<div></div>
@@ -137,7 +137,7 @@ width: 100%;margin-top: 20px;">
 									</td>
 									<td class="line_cost" width="1%">
 										<div class="view">
-											<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format(format_amount($meta[0]), 2, ',', '.'); ?></span>
+											<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format(floatval($meta[0]), 2, ',', '.'); ?></span>
 										</div>
 									</td>
 								</tr>
@@ -160,7 +160,7 @@ width: 100%;margin-top: 20px;">
 									<td class="label">Amount left to be Captured:</td>
 									<td width="1%"></td>
 									<td class="total">
-										<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format((float)$order->get_total() - (float)$captured_amount + $refunded_amount, 2, ',', '.');
+										<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo ( $refunded_amount ) ? number_format(0, 2, ',', '.') : number_format((float)$order->get_total() - (float)$captured_amount, 2, ',', '.');
 
 										if ( ((float)$order->get_total() - $captured_amount) == 0 ) {
 											update_post_meta( $order->get_id(),'full_captured_amount', 'true' );
@@ -181,7 +181,7 @@ width: 100%;margin-top: 20px;">
 				<table class="woocommerce_order_items" cellspacing="0" cellpadding="0">
 					<tbody id="order_refunds">
 						<?php foreach( get_post_meta( $order->get_id() ) as $key => $meta ) :?>
-							<?php if( strpos($key, 'anyday_refunded_payment') !== false ) : $refunded_amount = $refunded_amount + format_amount($meta[0]);?>
+							<?php if( strpos($key, 'anyday_refunded_payment') !== false ) : $refunded_amount = $refunded_amount + floatval($meta[0]);?>
 								<tr class="refund ">
 									<td class="thumb">
 										<div></div>
@@ -192,7 +192,7 @@ width: 100%;margin-top: 20px;">
 									</td>
 									<td class="line_cost" width="1%">
 										<div class="view">
-											<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format(format_amount($meta[0]), 2, ',', '.'); ?></span>
+											<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol"><?php echo $order->get_currency(); ?></span><?php echo number_format(floatval($meta[0]), 2, ',', '.'); ?></span>
 										</div>
 									</td>
 								</tr>
@@ -479,7 +479,7 @@ width: 100%;margin-top: 20px;">
 		$captured_amount = 0;
 		foreach( get_post_meta( $order->get_id() ) as $key => $meta ) {
 			if( strpos($key, 'anyday_captured_payment') !== false ) {
-				$captured_amount += format_amount($meta[0]);
+				$captured_amount += floatval($meta[0]);
 			}
 		}
 		return $captured_amount;
@@ -493,7 +493,7 @@ width: 100%;margin-top: 20px;">
 		$refunded_amount = 0;
 		foreach (get_post_meta($order->get_id()) as $key => $meta) {
 			if (strpos($key, 'anyday_refunded_payment') !== false) {
-					$refunded_amount += format_amount($meta[0]);
+					$refunded_amount += floatval($meta[0]);
 			}
 		}
 		return $refunded_amount;

--- a/includes/events/AnydayEventRefund.php
+++ b/includes/events/AnydayEventRefund.php
@@ -31,14 +31,11 @@ class AnydayEventRefund extends AnydayEvent {
 				$this->order->add_order_note( 
 					sprintf(
 						wp_kses( $message, array( 'br' => array() ) ),
-						number_format($this->data['Transaction']['Amount'], 2, ',', '.'),
+						format_amount($this->data['Transaction']['Amount']),
 						$this->order->get_currency()
 					)
 				);
-				update_post_meta( $this->order->get_id(), date("Y-m-d_h:i:sa") . '_anyday_refunded_payment', wc_clean( number_format($this->data['Transaction']['Amount'], 2, ',', '.') ) );
-				if( ! $this->get_is_pending() ) {
-					$this->order->update_status( 'refunded' );
-				}
+				update_post_meta( $this->order->get_id(), date("Y-m-d_h:i:sa") . '_anyday_refunded_payment', wc_clean( format_amount( $this->data['Transaction']['Amount'] ) ) );
 			break;
 		}
 		return;

--- a/includes/events/AnydayEventRefund.php
+++ b/includes/events/AnydayEventRefund.php
@@ -31,11 +31,11 @@ class AnydayEventRefund extends AnydayEvent {
 				$this->order->add_order_note( 
 					sprintf(
 						wp_kses( $message, array( 'br' => array() ) ),
-						format_amount($this->data['Transaction']['Amount']),
+						number_format($this->data['Transaction']['Amount'], 2, ',', '.'),
 						$this->order->get_currency()
 					)
 				);
-				update_post_meta( $this->order->get_id(), date("Y-m-d_h:i:sa") . '_anyday_refunded_payment', wc_clean( format_amount( $this->data['Transaction']['Amount'] ) ) );
+				update_post_meta( $this->order->get_id(), date("Y-m-d_h:i:sa") . '_anyday_refunded_payment', wc_clean( $this->data['Transaction']['Amount'] ) );
 			break;
 		}
 		return;


### PR DESCRIPTION
https://manaosoftware.atlassian.net/browse/AD-4334

Actual behaviour:
- If total order amount is 99.99 DKK and doing full capture, then details page was showing 99,00 DKK has been captured.
- So as per calculations 0.99 are pending to capture which was captured already giving error.

Expected behaviour:
- if total order amount is 99.99 DKK and capturing full amount, should show capture full capture has been process and merchant should not able to capture.
---

https://manaosoftware.atlassian.net/browse/AD-4339
Actual behaviour:
- After partial capture and partial refund, "Amount left to refund" calculated wrong

Expected behaviour:
- After partial capture and partial refund, "Amount left to refund" fields should show correct amount.