### PR TITLE
Fixing decimal capture bug and misleading calculations on order details page.

### DIFF
--- a/assets/admin/js/anyday-admin.js
+++ b/assets/admin/js/anyday-admin.js
@@ -57,11 +57,17 @@
     });
 
     function validateAmount(amount) {
-      let amtPattern = /^((?:\d{1,3}(?:[\s,]\d{3})+|\d+)(?:.\d{0,2}$))$|^((?:\d{1,3}(?:[\s.]\d{3})+|\d+)(?:,\d{0,2}$)|(^\d+$))$/;
+      let amtPattern = /^((?:\d{1,3}((?:[\s,]\d{3})+|(?:,\d{0,2}))(?:\.\d{0,2})?)$|^(?:\d{1,3}((?:[\s.]\d{3})+|(?:\.\d{0,2}))(?:\,\d{0,2})?)$|(^\d+[,\.]?)$|(?:\d+[,\.]\d{0,2})$)/;
       var dotPattern = [];
       var zeroReg    = /^0+$/;
       var amt        = false;
       var dec, decLength;
+      if ((amount.charAt(0) == '.' || amount.charAt(0) == ',')) {
+        dotPattern = amount.match(/[,|\.]/g);
+        if (dotPattern.length == 1) {
+          amount = "0" + amount;
+        }
+      }
       if(amtPattern.test(amount)) {
         dotPattern = amount.match(/[,|\.]/g);
         amt = amount.match(/\d+/g).join('');
@@ -70,7 +76,9 @@
         if(dotPattern && dotPattern.length > 0) {
           dec = dotPattern[dotPattern.length - 1];
           decLength = amount.split(dec)[1].length;
-          amt = amt.substring(0, amt.length - decLength) + "." + amt.substring(amt.length - decLength);
+          if ((amount.split(dec)[0] == "0" && dotPattern.length != 1) || decLength <= 2 ) {
+            amt = amt.substring(0, amt.length - decLength) + "." + amt.substring(amt.length - decLength);
+          }
         } else {
           return amt;
         }

--- a/includes/classes/AnydayPayment.php
+++ b/includes/classes/AnydayPayment.php
@@ -127,7 +127,6 @@ class AnydayPayment
 		$id = ($order_id) ? $order_id : $_POST['orderId'];
 		$order = wc_get_order( $id );
 		$amount = ($amount) ? $amount : $_POST['amount'];
-		$amount = number_format($amount, 2, ',', '');
 		$request = $this->adm_api_capture( $order, $amount );
 
 		if ( $request ) {
@@ -285,7 +284,6 @@ class AnydayPayment
 		$id = ($order_id) ? $order_id : $_POST['orderId'];
 		$order = wc_get_order( $id );
 		$amount = ($amount) ? $amount : $_POST['amount'];
-		$amount = number_format($amount, 2, ',', '');
 		$request = $this->adm_api_refund( $order, $amount );
 
 		if( $request ) {

--- a/includes/classes/Assets.php
+++ b/includes/classes/Assets.php
@@ -14,10 +14,10 @@ class Assets
     	wp_enqueue_script( 'anyday-admin-javascript', ADM_URL . 'assets/admin/js/anyday-admin.js', array(), false, true );
         wp_localize_script( 'anyday-admin-javascript', 'anyday', array(
             "ajaxUrl" => admin_url( 'admin-ajax.php' ),
-            "capturePrompt" => __( "Enter amount to be captured. Please note the amount cannot be higher than the order total!", "adm" ),
+            "capturePrompt" => __( "Enter an amount to be captured. You may enter an integer e.g. 1500 or 250, or you may enter decimals e.g. 1.500,00 or 250,00. If you enter a decimal in the thousandths place, you must use two decimals. e.g. 1.500,00", "adm" ),
             "capturePromptValidation" => __( "Please enter numeric value!", "adm" ),
             "cancelConfirmation" => __( "Are you sure you want to cancel this order? This action cannot be undone.", "adm" ),
-            "refundConfirmation" => __( "Are you sure you want to refund this order? This action cannot be undone.", "adm" )
+            "refundConfirmation" => __( "Are you sure you want to refund this order? This action cannot be undone. Enter an amount to be refunded. You may enter an integer e.g. 1500 or 250, or you may enter decimals e.g. 1.500,00 or 250,00. If you enter a decimal in the thousandths place, you must use two decimals. e.g. 1.500,00", "adm" )
         ));
 
         wp_enqueue_style( 'anyday-admin-stylesheet', ADM_URL . 'assets/admin/css/anyday-admin.css' );


### PR DESCRIPTION
[…ture action backend](https://manaosoftware.atlassian.net/browse/AD-4334

Actual behaviour:
- If total order amount is 99.99 DKK and doing full capture, then details page was showing 99,00 DKK has been captured.
- So as per calculations 0.99 are pending to capture which was captured already giving error.

Expected behaviour:
- if total order amount is 99.99 DKK and capturing full amount, should show capture full capture has been process and merchant should not able to capture.
---

https://manaosoftware.atlassian.net/browse/AD-4339
Actual behaviour:
- After partial capture and partial refund, "Amount left to refund" calculated wrong

Expected behaviour:
- After partial capture and partial refund, "Amount left to refund" fields should show correct amount.)