### PR TITLE
Preparing to release 1.7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Description: Anyday is a new way to pay. An interest-free financing solution with no fees or interest for your customers.
 
-Version: 1.7.3
+Version: 1.7.4
 
 ## Plugin installation
 
@@ -41,3 +41,5 @@ Version 1.7.1 - Updating not to fetch scripts on update immediatly on plugin upg
 Version 1.7.2 - Changed JS file cached with CURL.
 
 Version 1.7.3 - Adding bulk order status update in backend, Anyday payment is enabled for orders with payments greater than and equals to 300 DKK, Stock levels should update only when order is completed or processing. Stock added back on order cancelled and refunded, Fixing number format throughout the plugin, Adding validation to check number format while input for capture/refund from the backend, Fixing cached JS URL for some instances using permalinks, Fixed backend configuration page which was broken, Minimum price limit for pricetag isn't working for on-sale product.
+
+Version 1.7.4 - Fixing calculations after capture/refund actions on order details page, Fixing decimal point issue while entering amount to capture/refund. You may enter an integer e.g. 1500 or 250, or you may enter decimals e.g. 1.500,00 or 250,00. If you enter a decimal in the thousandths place, you must use two decimals. e.g. 1.500,00

--- a/adm-core.php
+++ b/adm-core.php
@@ -2,8 +2,8 @@
 /*
 Plugin Name: Anyday WooCommerce
 Plugin URI: https://www.anyday.io
-Description: A fair and transparent online payment solution for you and your customers
-Version: 1.7.3
+Description: Anyday is a new way to pay. An interest-free financing solution with no fees or interest for your customers.
+Version: 1.7.4
 Requires at least: 5.2
 Requires PHP: 7.1.33
 Author: Anyday
@@ -27,7 +27,7 @@ if ( ! defined( 'WPINC' ) ) {
  **/
 if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
 
-	define( 'ADM_VERSION', '1.7.3' );
+	define( 'ADM_VERSION', '1.7.4' );
 	define( 'ADM_PATH', plugin_dir_path( __FILE__ ) );
 	define( 'ADM_URL', plugin_dir_url( __FILE__ ) );
 	define( 'ADM_PLUGIN_SLUG', "am-wordpress" );

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: anyday2020
 Tags: Payments, Instalments, WooCommerce, Payment Gateway, Buy Now Pay Later, BNPL, Conversion Rate, Basket Size, Anyday
 Requires at least: 4.3.1
-Tested up to: 5.8.1
-Stable tag: 1.7.3
+Tested up to: 5.9.1
+Stable tag: 1.7.4
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -115,3 +115,9 @@ Anyday assumes all credit risk as soon as a purchase is made. You will receive a
 - Fixing cached JS URL for some instances using permalinks.
 - Fixed backend configuration page which was broken.
 - Minimum price limit for pricetag isn't working for on-sale product.
+
+= 1.7.4 =
+
+#### 👾 Bug Fixes
+- Fixed miscalculations on order details page, after payment capture/refunds.
+- Fixed decimal point bug which captures incorrect amount due to wrong decimal value conversion. Now users would be able to enter an integer e.g. 1500 or 250, or may enter decimals e.g. 1.500,00 or 250,00. If entered a decimal in the thousandths place, you must use two decimals. e.g. 1.500,00


### PR DESCRIPTION
#### 👾 Bug Fixes
- Fixed miscalculations on order details page, after payment capture/refunds.
- Fixed decimal point bug which captures incorrect amount due to wrong decimal value conversion. Now users would be able to enter an integer e.g. 1500 or 250, or may enter decimals e.g. 1.500,00 or 250,00. If entered a decimal in the thousandths place, you must use two decimals. e.g. 1.500,00
