### PR TITLE
Fixing hook in the plugin which returns blank setting array

### DIFF
--- a/includes/classes/Core.php
+++ b/includes/classes/Core.php
@@ -109,10 +109,11 @@ class Core
      * Load the plugin settings
      *@method adm_add_settings
      */
-	public function adm_add_settings()
+	public function adm_add_settings($settings)
 	{
-    	return new Settings();
-    }
+		new Settings();
+		return $settings;
+	}
 
 	/**
      * Register the Anyday payment gateway


### PR DESCRIPTION
https://manaosoftware.atlassian.net/browse/AD-4303

Fixing issue in hook function which was returning blank settings array.